### PR TITLE
Feature/performance

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2018, 2019 ethframe
+Copyright (c) 2018-2020 ethframe
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/benchmarks/jugs.py
+++ b/benchmarks/jugs.py
@@ -1,0 +1,84 @@
+import pyperf
+from mk.arithmetic import add, gte, lte
+from mk.core import conj, disj, eq
+from mk.disequality import neq
+from mk.dsl import conde, conjp, delay, fresh, run
+from mk.unify import Var
+
+
+BIG = 5
+SMALL = 3
+
+
+@delay
+def jugs(states):
+    return disj(
+        eq([(0, 0, "")], states),
+        fresh(
+            8,
+            lambda big, small, act, prev_big, prev_small, tail, _, __: conjp(
+                eq([(big, small, act), tail, ...], states),
+                eq([(prev_big, prev_small, _), __, ...], tail),
+                conde(
+                    [
+                        conde(
+                            [
+                                eq(small, prev_small),
+                                conde(
+                                    [eq(big, BIG), eq(act, "fill big")],
+                                    [eq(big, 0), eq(act, "empty big")])],
+                            [
+                                fresh(
+                                    lambda total: conjp(
+                                        conde(
+                                            [eq(big, BIG), eq(act, "to big")],
+                                            [
+                                                eq(small, SMALL),
+                                                eq(act, "to small")],
+                                            [
+                                                eq(small, 0), neq(big, BIG),
+                                                eq(act, "to big")],
+                                            [
+                                                eq(big, 0), neq(small, SMALL),
+                                                eq(act, "to small")]),
+                                        add(big, small, total),
+                                        add(prev_big, prev_small, total)))]),
+                        neq(big, prev_big)],
+                    [
+                        eq(big, prev_big),
+                        conde(
+                            [eq(small, SMALL), eq(act, "fill small")],
+                            [eq(small, 0), eq(act, "empty small")]),
+                        neq(small, prev_small)]),
+                gte(big, 0), lte(big, BIG),
+                gte(small, 0), lte(small, SMALL),
+                jugs(tail),
+            )))
+
+
+def solve():
+    solutions = {}
+
+    states = Var()
+    big = Var()
+    small = Var()
+    _ = Var()
+    __ = Var()
+
+    for i in range(1, BIG + 1):
+        p = conjp(
+            eq([(big, small, _), __, ...], states),
+            disj(
+                eq(big, i),
+                conj(neq(big, i), eq(small, i)),
+            ),
+            jugs(states)
+        )
+        for answer in run(1, states, p):
+            solutions[i] = list(reversed(answer))
+
+    return solutions
+
+
+runner = pyperf.Runner()
+runner.bench_func('jugs', solve)

--- a/mk/core.py
+++ b/mk/core.py
@@ -45,6 +45,10 @@ class WatchList(dict):
         return WatchList((k, v.copy()) for k, v in self.items())
 
 
+def initial():
+    return {}, {}, WatchList()
+
+
 def copy(state):
     subst, types, cons = state
     return subst.copy(), types.copy(), cons.copy()

--- a/mk/disequality.py
+++ b/mk/disequality.py
@@ -1,5 +1,5 @@
 from .stream import MZero, Unit
-from .unify import typeof, unify
+from .unify import Var, unify, walk
 
 
 def neq(u, v):
@@ -10,8 +10,6 @@ def neq(u, v):
             return Unit(state)
         if not a:
             return MZero()
-        if unify(typeof(u), typeof(v), types.copy()) is None:
-            return Unit(state)
         cons[a[0]].append(_goal)
         return Unit(state)
     return _goal
@@ -20,11 +18,16 @@ def neq(u, v):
 def neqt(v, t):
     def _goal(state):
         subst, types, cons = state
-        a = unify(typeof(v), t, types.copy())
-        if a is None:
-            return Unit(state)
-        if not a:
+        x = walk(v, subst)
+        t_x = type(x)
+        if t_x is Var:
+            t_x = types.get(x)
+            if t_x is None:
+                cons[x].append(_goal)
+                return Unit(state)
+            elif t_x is t:
+                return MZero()
+        elif t_x is t:
             return MZero()
-        cons[a[0]].append(_goal)
         return Unit(state)
     return _goal

--- a/mk/ext/lists.py
+++ b/mk/ext/lists.py
@@ -40,31 +40,14 @@ def _unify_pairs(u, v, subst):
         return a
 
 
-def _list(u, v, subst):
-    if isinstance(v, list):
-        v = _convert_list(v)
-    elif not (type(v) is Pair or v is null):
-        return None
-    u = _convert_list(u)
-    if u is null:
-        if u is v:
-            return []
-        return None
-    return _unify_pairs(u, v, subst)
-
-
 def _null(u, v, subst):
-    if isinstance(v, list):
-        v = _convert_list(v)
     if v is not null:
         return None
     return []
 
 
 def _pair(u, v, subst):
-    if isinstance(v, list):
-        v = _convert_list(v)
-    elif not type(v) is Pair:
+    if type(v) is not Pair:
         return None
     return _unify_pairs(u, v, subst)
 
@@ -72,8 +55,6 @@ def _pair(u, v, subst):
 def _reify_pair(v, subst, types, cnt):
     car = reify_value(v.car, subst, types, cnt)
     cdr = reify_value(v.cdr, subst, types, cnt)
-    if cdr is null:
-        return [car]
     if isinstance(cdr, list):
         return [car] + cdr
     return [car, cdr, ...]
@@ -83,7 +64,7 @@ def _reify_null(v, subst, types, cnt):
     return []
 
 
-register_exact(list, convert=_convert_list, unify=_list)
+register_exact(list, convert=_convert_list)
 register_exact(Pair, unify=_pair, reify=_reify_pair)
 register_exact(_Null, unify=_null, reify=_reify_null)
 

--- a/mk/run.py
+++ b/mk/run.py
@@ -20,10 +20,10 @@ _reifiers = SingledispatchCache()
 
 
 def reify_type(v, types, cnt):
-    v = walk(v, types)
-    if isinstance(v, Var):
+    t_v = types.get(v)
+    if t_v is None:
         return "_{}".format(cnt[v])
-    return v.__name__
+    return t_v.__name__
 
 
 def reify_value(v, subst, types, cnt):

--- a/mk/run.py
+++ b/mk/run.py
@@ -1,7 +1,7 @@
 from collections import defaultdict
 from itertools import count, islice
 
-from .core import WatchList
+from .core import initial
 from .dispatch import SingledispatchCache
 from .stream import unfold
 from .unify import Var, walk
@@ -40,10 +40,6 @@ def reify(v, state):
     subst, types, cons = state
     cnt = defaultdict(count().__next__)
     return reify_value(v, subst, types, cnt)
-
-
-def initial():
-    return {}, {}, WatchList()
 
 
 def run(c, v, g):

--- a/mk/stream.py
+++ b/mk/stream.py
@@ -1,4 +1,6 @@
 class MZero:
+    __slots__ = ()
+
     def mplus(self, stream):
         return stream
 
@@ -10,6 +12,8 @@ class MZero:
 
 
 class Unit:
+    __slots__ = ('head',)
+
     def __init__(self, head):
         self.head = head
 
@@ -24,6 +28,8 @@ class Unit:
 
 
 class Cons:
+    __slots__ = ('head', 'tail')
+
     def __init__(self, head, tail):
         self.head = head
         self.tail = tail
@@ -39,7 +45,7 @@ class Cons:
 
 
 class Thunk:
-    __slots__ = ("thunk",)
+    __slots__ = ('thunk',)
 
     def __init__(self, thunk):
         self.thunk = thunk

--- a/mk/stream.py
+++ b/mk/stream.py
@@ -6,7 +6,21 @@ class MZero:
         return self
 
     def next(self):
-        return self
+        return None, None
+
+
+class Unit:
+    def __init__(self, head):
+        self.head = head
+
+    def mplus(self, stream):
+        return Cons(self.head, stream)
+
+    def bind(self, goal):
+        return goal(self.head)
+
+    def next(self):
+        return self.head, None
 
 
 class Cons:
@@ -21,21 +35,7 @@ class Cons:
         return goal(self.head).mplus(Thunk(lambda: self.tail.bind(goal)))
 
     def next(self):
-        return self.tail
-
-
-class Unit:
-    def __init__(self, head):
-        self.head = head
-
-    def mplus(self, stream):
-        return Cons(self.head, stream)
-
-    def bind(self, goal):
-        return goal(self.head)
-
-    def next(self):
-        return MZero()
+        return self.head, self.tail
 
 
 class Thunk:
@@ -51,13 +51,11 @@ class Thunk:
         return Thunk(lambda: self.thunk().bind(goal))
 
     def next(self):
-        return self.thunk()
+        return None, self.thunk()
 
 
 def unfold(stream):
-    while type(stream) is not MZero:
-        while type(stream) is Thunk:
-            stream = stream.next()
-        while type(stream) in (Cons, Unit):
-            yield stream.head
-            stream = stream.next()
+    while stream is not None:
+        head, stream = stream.next()
+        if head is not None:
+            yield head

--- a/mk/unify.py
+++ b/mk/unify.py
@@ -42,12 +42,6 @@ def convert(x):
     return x
 
 
-def typeof(x):
-    if type(x) is Var:
-        return x
-    return type(convert(x))
-
-
 _unifiers = SingledispatchCache()
 
 

--- a/mk/unify.py
+++ b/mk/unify.py
@@ -6,12 +6,13 @@ class Var:
 
 
 def walk(v, subst):
-    while type(v) is Var:
-        u = subst.get(v)
-        if u is None:
-            return v
+    if type(v) is not Var:
+        return convert(v)
+    u = subst.get(v)
+    while type(u) is Var:
         v = u
-    return v
+        u = subst.get(v)
+    return v if u is None else u
 
 
 _occurs_checkers = SingledispatchCache()
@@ -50,15 +51,15 @@ def typeof(x):
 _unifiers = SingledispatchCache()
 
 
-def unify(u, v, subst, list=list):
+def unify(u, v, subst):
     u = walk(u, subst)
     v = walk(v, subst)
     if type(u) is Var:
         if u is v:
             return []
-        return assoc(u, convert(v), subst)
+        return assoc(u, v, subst)
     if type(v) is Var:
-        return assoc(v, convert(u), subst)
+        return assoc(v, u, subst)
     fn = _unifiers[type(u)]
     if fn:
         return fn(u, v, subst)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -16,7 +16,12 @@ GOALS_DATA = [
 
     (eqt(a, int), [{}]),
     (conj(eq(a, 1), eqt(a, int)), [{a: 1}]),
+    (conj(eqt(a, int), eq(a, 1)), [{a: 1}]),
     (conj(eq(a, 1), eqt(a, str)), []),
+    (conj(eqt(a, str), eq(a, 1)), []),
+
+    (conj(eqt(a, int), eqt(a, int)), [{}]),
+    (conj(eqt(a, int), eqt(a, str)), []),
 
     (conj(conj(eqt(a, int), eqt(b, int)), eq(a, b)), [{a: b}]),
     (conj(conj(eqt(a, int), eqt(b, str)), eq(a, b)), []),

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -1,8 +1,12 @@
 import pytest
-from mk.stream import Unit, unfold
+from mk.stream import MZero, Thunk, Unit, unfold
 
 UNFOLD_DATA = [
+    (MZero(), []),
+
     (Unit(1), [1]),
+    (MZero().mplus(Unit(1)), [1]),
+
     (Unit(1).mplus(Unit(2)), [1, 2]),
     (Unit(1).mplus(Unit(2).mplus(Unit(3))), [1, 2, 3]),
 
@@ -10,6 +14,8 @@ UNFOLD_DATA = [
 
     (Unit(1).bind(lambda a: Unit(a + 1)), [2]),
     (Unit(1).mplus(Unit(2)).bind(lambda a: Unit(a + 1)), [2, 3]),
+
+    (Thunk(lambda: Unit(1)).mplus(Thunk(lambda: Unit(2))), [1, 2]),
 ]
 
 


### PR DESCRIPTION
Various optimizations:
* Type constraints checked without `unify`
* Reduced number of checks inside loop in `walk`
* Call to `convert` is avoided if term was retrieved from substitution
* `unfold` does not rely on stream types

```
+-----------+--------+------------------------------+
| Benchmark | master | performance                  |
+===========+========+==============================+
| jugs      | 104 ms | 82.8 ms: 1.25x faster (-20%) |
+-----------+--------+------------------------------+
```