### PR TITLE
Remove thunks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ python:
   - 3.7
 
 install:
-  - pip install pytest pytest-cov codecov
+  - pip install -U pytest pytest-cov codecov
   - pip install -e .
 
 script: pytest --cov=mk/ --cov-branch tests/

--- a/benchmarks/lisp_interpreter.py
+++ b/benchmarks/lisp_interpreter.py
@@ -1,0 +1,134 @@
+from collections import namedtuple
+
+import pyperf
+from mk.core import conj, disj, eq, eqt
+from mk.disequality import neq
+from mk.dsl import conde, conjp, delay, fresh
+from mk.ext.lists import no_item
+from mk.run import run
+from mk.unify import Var
+
+
+class Ident(str):
+    def __repr__(self):
+        return self
+
+    def __eq__(self, other):
+        return type(self) is type(other) and super().__eq__(other)
+
+
+class Symbol(Ident):
+    pass
+
+
+class Builtin(Ident):
+    pass
+
+
+Closure = namedtuple("Closure", "arg, body, env")
+Env = namedtuple("Env", "var, val, env")
+
+
+@delay
+def lookup(var, env, out):
+    return fresh(3, lambda rest, sym, val: conj(
+        eq(Env(sym, val, rest), env),
+        conde(
+            (eq(sym, var), eq(val, out)),
+            (neq(sym, var), lookup(var, rest, out))
+        )
+    ))
+
+
+@delay
+def missing(var, env):
+    return disj(
+        eq((), env),
+        fresh(3, lambda rest, sym, val: conjp(
+            eq(Env(sym, val, rest), env), neq(sym, var),
+            missing(var, rest),
+        )),
+    )
+
+
+@delay
+def eval_list(lst, env, out):
+    return conde(
+        (eq([], lst), eq([], out)),
+        fresh(4, lambda h, t, oh, ot: conjp(
+            eq([h, t, ...], lst), eq([oh, ot, ...], out),
+            eval_expr(h, env, oh), eval_list(t, env, ot),
+        ))
+    )
+
+
+def is_internal(a):
+    return isinstance(a, (Closure, Builtin))
+
+
+quote, list_, lambda_ = map(Symbol, "quote list lambda".split())
+car, cdr = map(Symbol, "car cdr".split())
+car_fn, cdr_fn = map(Builtin, "car cdr".split())
+
+
+def builtin(fn, out):
+    return conde(
+        (eq(fn, car), eq(out, car_fn)),
+        (eq(fn, cdr), eq(out, cdr_fn)),
+    )
+
+
+def eval_builtin(fn, arg, out):
+    return fresh(lambda t: conde(
+        (eq(fn, car_fn), eq([out, t, ...], arg)),
+        (eq(fn, cdr_fn), eq([t, out, ...], arg)),
+    ))
+
+
+@delay
+def eval_expr(exp, env, out):
+    return conde(
+        (
+            eq([quote, out], exp), no_item(out, is_internal),
+            missing(quote, env),
+        ),
+        fresh(lambda lst: conjp(
+            eq([list_, lst, ...], exp),
+            missing(list_, env), eval_list(lst, env, out),
+        )),
+        fresh(5, lambda fn, arg, var, body, cenv: conj(
+            eval_list(exp, env, [fn, arg]),
+            conde(
+                eval_builtin(fn, arg, out),
+                (
+                    eq(Closure(var, body, cenv), fn),
+                    eval_expr(body, Env(var, arg, cenv), out),
+                ),
+            )
+        )),
+        fresh(2, lambda var, body: conjp(
+            eq([lambda_, [var], body], exp), eq(Closure(var, body, env), out),
+            eqt(var, Symbol), missing(lambda_, env),
+        )),
+        (eqt(exp, Symbol), lookup(exp, env, out)),
+        (builtin(exp, out), missing(exp, env)),
+    )
+
+
+def format_sexpr(s):
+    if isinstance(s, list):
+        if len(s) == 2 and s[0] == Symbol("quote"):
+            return "'" + format_sexpr(s[1])
+        return "({})".format(" ".join(format_sexpr(e) for e in s))
+    if s is Ellipsis:
+        return "..."
+    return repr(s)
+
+
+def quines():
+    q = Var()
+    return next(run(0, q, eval_expr(q, (), q)))
+
+
+runner = pyperf.Runner()
+runner.bench_func('quines', quines)

--- a/mk/dsl.py
+++ b/mk/dsl.py
@@ -29,14 +29,37 @@ def conde(*ggs):
     return disjp(*(gs if callable(gs) else conjp(*gs) for gs in ggs))
 
 
+class Zzz:
+    __slots__ = ('fn', 'state')
+
+    def __init__(self, fn, state):
+        self.fn = fn
+        self.state = state
+
+    def __call__(self):
+        return self.fn()(self.state)
+
+
 def zzz(thunk):
-    return lambda state: Thunk(lambda: thunk()(state))
+    return lambda state: Thunk(Zzz(thunk, state))
+
+
+class Delay:
+    __slots__ = ('fn', 'args', 'state')
+
+    def __init__(self, fn, args, state):
+        self.fn = fn
+        self.args = args
+        self.state = state
+
+    def __call__(self):
+        return self.fn(*self.args)(self.state)
 
 
 def delay(fn):
     @wraps(fn)
     def _constructor(*args):
-        return lambda state: Thunk(lambda: fn(*args)(state))
+        return lambda state: Thunk(Delay(fn, args, state))
     return _constructor
 
 

--- a/mk/dsl.py
+++ b/mk/dsl.py
@@ -30,42 +30,42 @@ def conde(*ggs):
 
 
 class Apply(Stream):
-    __slots__ = ('state', 'delay')
+    __slots__ = ('state', 'goal')
 
-    def __init__(self, state, delay):
+    def __init__(self, state, goal):
         self.state = state
-        self.delay = delay
+        self.goal = goal
 
     def mplus(self, stream):
-        return Apply(self.state, MPlusDelay(stream, self.delay))
+        return Apply(self.state, MPlusGoal(stream, self.goal))
 
     def bind(self, goal):
-        return Apply(self.state, BindDelay(self.delay, goal))
+        return Apply(self.state, BindGoal(self.goal, goal))
 
     def next(self):
-        return None, self.delay(self.state)
+        return None, self.goal(self.state)
 
 
-class MPlusDelay:
-    __slots__ = ('stream', 'delay')
+class MPlusGoal:
+    __slots__ = ('stream', 'goal')
 
-    def __init__(self, stream, delay):
+    def __init__(self, stream, goal):
         self.stream = stream
-        self.delay = delay
-
-    def __call__(self, state):
-        return self.stream.mplus(self.delay(state))
-
-
-class BindDelay:
-    __slots__ = ('delay', 'goal')
-
-    def __init__(self, delay, goal):
-        self.delay = delay
         self.goal = goal
 
     def __call__(self, state):
-        return self.delay(state).bind(self.goal)
+        return self.stream.mplus(self.goal(state))
+
+
+class BindGoal:
+    __slots__ = ('left', 'right')
+
+    def __init__(self, left, right):
+        self.left = left
+        self.right = right
+
+    def __call__(self, state):
+        return self.left(state).bind(self.right)
 
 
 class Zzz:

--- a/mk/dsl.py
+++ b/mk/dsl.py
@@ -2,7 +2,7 @@ from functools import reduce, wraps
 
 from .core import copy
 from .run import run
-from .stream import Thunk
+from .stream import ThunkStream
 from .unify import Var, walk
 
 
@@ -29,7 +29,7 @@ def conde(*ggs):
     return disjp(*(gs if callable(gs) else conjp(*gs) for gs in ggs))
 
 
-class Zzz:
+class Zzz(ThunkStream):
     __slots__ = ('fn', 'state')
 
     def __init__(self, fn, state):
@@ -41,10 +41,10 @@ class Zzz:
 
 
 def zzz(thunk):
-    return lambda state: Thunk(Zzz(thunk, state))
+    return lambda state: Zzz(thunk, state)
 
 
-class Delay:
+class Delay(ThunkStream):
     __slots__ = ('fn', 'args', 'state')
 
     def __init__(self, fn, args, state):
@@ -59,7 +59,7 @@ class Delay:
 def delay(fn):
     @wraps(fn)
     def _constructor(*args):
-        return lambda state: Thunk(Delay(fn, args, state))
+        return lambda state: Delay(fn, args, state)
     return _constructor
 
 

--- a/mk/dsl.py
+++ b/mk/dsl.py
@@ -2,7 +2,7 @@ from functools import reduce, wraps
 
 from .core import copy
 from .run import run
-from .stream import Stream
+from .stream import Apply
 from .unify import Var, walk
 
 
@@ -27,45 +27,6 @@ def disjp(g, *gs):
 
 def conde(*ggs):
     return disjp(*(gs if callable(gs) else conjp(*gs) for gs in ggs))
-
-
-class Apply(Stream):
-    __slots__ = ('state', 'goal')
-
-    def __init__(self, state, goal):
-        self.state = state
-        self.goal = goal
-
-    def mplus(self, stream):
-        return Apply(self.state, MPlusGoal(stream, self.goal))
-
-    def bind(self, goal):
-        return Apply(self.state, BindGoal(self.goal, goal))
-
-    def next(self):
-        return None, self.goal(self.state)
-
-
-class MPlusGoal:
-    __slots__ = ('stream', 'goal')
-
-    def __init__(self, stream, goal):
-        self.stream = stream
-        self.goal = goal
-
-    def __call__(self, state):
-        return self.stream.mplus(self.goal(state))
-
-
-class BindGoal:
-    __slots__ = ('left', 'right')
-
-    def __init__(self, left, right):
-        self.left = left
-        self.right = right
-
-    def __call__(self, state):
-        return self.left(state).bind(self.right)
 
 
 class Zzz:

--- a/mk/stream.py
+++ b/mk/stream.py
@@ -126,6 +126,45 @@ class BindThunk(ThunkStream):
         return self.thunk().bind(self.goal)
 
 
+class Apply(Stream):
+    __slots__ = ('state', 'goal')
+
+    def __init__(self, state, goal):
+        self.state = state
+        self.goal = goal
+
+    def mplus(self, stream):
+        return Apply(self.state, MPlusGoal(stream, self.goal))
+
+    def bind(self, goal):
+        return Apply(self.state, BindGoal(self.goal, goal))
+
+    def next(self):
+        return None, self.goal(self.state)
+
+
+class MPlusGoal:
+    __slots__ = ('stream', 'goal')
+
+    def __init__(self, stream, goal):
+        self.stream = stream
+        self.goal = goal
+
+    def __call__(self, state):
+        return self.stream.mplus(self.goal(state))
+
+
+class BindGoal:
+    __slots__ = ('left', 'right')
+
+    def __init__(self, left, right):
+        self.left = left
+        self.right = right
+
+    def __call__(self, state):
+        return self.left(state).bind(self.right)
+
+
 def unfold(stream):
     while stream is not None:
         head, stream = stream.next()

--- a/mk/stream.py
+++ b/mk/stream.py
@@ -1,4 +1,15 @@
-class MZero:
+class Stream:
+    def mplus(self, stream):
+        raise NotImplementedError()
+
+    def bind(self, stream):
+        raise NotImplementedError()
+
+    def next(self, stream):
+        raise NotImplementedError()
+
+
+class MZero(Stream):
     __slots__ = ()
 
     def mplus(self, stream):
@@ -11,7 +22,7 @@ class MZero:
         return None, None
 
 
-class Unit:
+class Unit(Stream):
     __slots__ = ('head',)
 
     def __init__(self, head):
@@ -27,7 +38,7 @@ class Unit:
         return self.head, None
 
 
-class Cons:
+class Cons(Stream):
     __slots__ = ('head', 'tail')
 
     def __init__(self, head, tail):
@@ -44,7 +55,7 @@ class Cons:
         return self.head, self.tail
 
 
-class Thunk:
+class Thunk(Stream):
     __slots__ = ('thunk',)
 
     def __init__(self, thunk):

--- a/mk/stream.py
+++ b/mk/stream.py
@@ -1,4 +1,4 @@
-class Stream:
+class Stream:  # pragma: no cover
     def mplus(self, stream):
         raise NotImplementedError()
 

--- a/tests/test_dsl.py
+++ b/tests/test_dsl.py
@@ -13,7 +13,8 @@ c = Var()
 def zzz_goal(a, b):
     return conde(
         eq(b, (1, a)),
-        (eq(a, 1), zzz(lambda: zzz_goal(2, b)))
+        (eq(a, 1), zzz(lambda: zzz_goal(2, b))),
+        (eq(a, 2), zzz(lambda: zzz_goal(3, b)), eq(a, b))
     )
 
 
@@ -21,7 +22,8 @@ def zzz_goal(a, b):
 def delay_goal(a, b):
     return conde(
         eq(b, (1, a)),
-        (eq(a, 1), delay_goal(2, b))
+        (eq(a, 1), delay_goal(2, b)),
+        (eq(a, 2), delay_goal(3, b), eq(a, b))
     )
 
 


### PR DESCRIPTION
Thunks are replaced with specialized stream objects. This change results in small performance improvement in all benchmarks:

```
+-----------+----------+------------------------------+
| Benchmark | master   | feature                      |
+===========+==========+==============================+
| jugs      | 80.5 ms  | 77.7 ms: 1.04x faster (-3%)  |
+-----------+----------+------------------------------+
| quines    | 1.31 sec | 1.23 sec: 1.07x faster (-6%) |
+-----------+----------+------------------------------+
```